### PR TITLE
Update requirements.yml

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -2,7 +2,7 @@ name: minerva_analysis
 channels:
   - conda-forge
 dependencies:
-  - Flask=1.1.2
+  - Flask=1.1.4
   - flask-sqlalchemy
   - nomkl
   - numpy


### PR DESCRIPTION
Flask 1.1.2 is [set up to require itsdangerous >= 0.24](https://github.com/pallets/flask/blob/1.1.2/setup.py#L58). The latest released (itsdangerous) version (2.10) deprecated the JSON API.

Instead of downgrading itsdangerous, I updated flask to 1.1.4